### PR TITLE
Revert pycares workaround

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,6 @@ Daemon which provides TLS client policy for Postfix via socketmap, according to 
 * pynetstring
 * PyYAML
 * (optional) uvloop
-* pycares>=2.3.0
 
 All dependency packages installed automatically if this package is installed via pip.
 

--- a/postfix_mta_sts_resolver/resolver.py
+++ b/postfix_mta_sts_resolver/resolver.py
@@ -64,12 +64,12 @@ class STSResolver(object):
 
         # Exactly one record should exist
         txt_records = [rec for rec in txt_records
-                       if rec.text.startswith(b'v=STSv1')]
+                       if rec.text.startswith('v=STSv1')]
         if len(txt_records) != 1:
             return STSFetchResult.NONE, None
 
         # Validate record
-        txt_record = txt_records[0].text.decode('latin-1')
+        txt_record = txt_records[0].text
         mta_sts_record = parse_mta_sts_record(txt_record)
         if (mta_sts_record.get('v', None) != 'STSv1'
                 or 'id' not in mta_sts_record):

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,3 @@ aiodns>=1.1.1
 aiohttp>=1.2.0
 PyYAML>=3.12
 uvloop>=0.11.0
-pycares>=2.3.0

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,6 @@ setup(name='postfix_mta_sts_resolver',
           'aiodns>=1.1.1',
           'aiohttp>=3.4.4',
           'PyYAML>=3.12',
-          'pycares>=2.3.0',
       ],
       scripts=[
           'mta-sts-daemon',


### PR DESCRIPTION
Thanks for creating this project!

In the process of creating a Debian package I noticed that current aiodns 2.0.0 with pycares 3.0.0 returns strings again. I propose the workaround for the indirect pycares dependency be dropped.