### PR TITLE
add cache grace time

### DIFF
--- a/config_examples/README.md
+++ b/config_examples/README.md
@@ -7,6 +7,7 @@ Reference for configuration values:
 * `host`: (str) daemon bind address
 * `port`: (int) daemon bind port
 * `reuse_port`: (bool) allow multiple instances to share same port (available on Unix, Windows)
+* `cache_grace`: (float) age of cache entries in seconds which do not require policy refresh and update. Default: 60
 * `cache`:
   * `type`: (str: `internal`|`sqlite`|`redis`) cache backend type
   * `options`:

--- a/postfix_mta_sts_resolver/defaults.py
+++ b/postfix_mta_sts_resolver/defaults.py
@@ -8,3 +8,4 @@ CONFIG_LOCATION = "/etc/postfix/mta-sts-daemon.yml"
 CACHE_BACKEND = "internal"
 INTERNAL_CACHE_SIZE = 10000
 REDIS_TIMEOUT = 5
+CACHE_GRACE = 60

--- a/postfix_mta_sts_resolver/utils.py
+++ b/postfix_mta_sts_resolver/utils.py
@@ -74,6 +74,7 @@ def populate_cfg_defaults(cfg):
     cfg['reuse_port'] = cfg.get('reuse_port', defaults.REUSE_PORT)
     cfg['shutdown_timeout'] = cfg.get('shutdown_timeout',
                                       defaults.SHUTDOWN_TIMEOUT)
+    cfg['cache_grace'] = cfg.get('cache_grace', defaults.CACHE_GRACE)
 
     if 'cache' not in cfg:
         cfg['cache'] = {}


### PR DESCRIPTION
**Purpose of proposed changes**

Cut performance penality and number of DNS requests for frequent requests for same domain having cached STS policy.

**Essential steps taken**

Added `cache_grace` time in order to designate period when cache entry doesn't require update or revalidation.