### PR TITLE
py35 compat fix

### DIFF
--- a/postfix_mta_sts_resolver/utils.py
+++ b/postfix_mta_sts_resolver/utils.py
@@ -183,17 +183,3 @@ def create_cache(type, options):
     else:
         raise NotImplementedError("Unsupported cache type!")
     return cache
-
-class NoDefault:
-    pass
-
-NODEFAULT = NoDefault()
-
-async def _anext(gen, default=NODEFAULT):
-    try:
-        return await gen.__anext__()
-    except StopAsyncIteration:
-        if default is NODEFAULT:
-            raise
-        else:
-            return default


### PR DESCRIPTION
**Purpose of proposed changes**

Fix Python 3.5 compatibility

**Essential steps taken**

Removed `yield` from coroutine usage.
