### PR TITLE
add default user-agent to mta-sts policy lookups

### DIFF
--- a/postfix_mta_sts_resolver/defaults.py
+++ b/postfix_mta_sts_resolver/defaults.py
@@ -13,3 +13,4 @@ SQLITE_THREADS = cpu_count()
 SQLITE_TIMEOUT = 5
 REDIS_TIMEOUT = 5
 CACHE_GRACE = 60
+USER_AGENT = "postfix-mta-sts-resolver"

--- a/postfix_mta_sts_resolver/resolver.py
+++ b/postfix_mta_sts_resolver/resolver.py
@@ -28,6 +28,8 @@ class STSResolver(object):
         self._http_timeout = aiohttp.ClientTimeout(total=timeout)
         self._proxy_info = aiohttp.helpers.proxies_from_env().get('https',
                                                                   None)
+        self._headers = {}
+        
         if self._proxy_info is None:
             self._proxy = None
             self._proxy_auth = None
@@ -86,6 +88,9 @@ class STSResolver(object):
                           domain +
                           '/.well-known/mta-sts.txt')
 
+        # Construct headers for MTA-STS policy fetch
+        self._headers["User-Agent"] = defaults.USER_AGENT
+        
         # Fetch actual policy
         try:
             async with aiohttp.ClientSession(loop=self._loop,
@@ -93,7 +98,7 @@ class STSResolver(object):
                                                  as session:
                 async with session.get(sts_policy_url,
                                        allow_redirects=False,
-                                       proxy=self._proxy,
+                                       proxy=self._proxy, headers=self._headers,
                                        proxy_auth=self._proxy_auth) as resp:
                     if resp.status != 200:
                         raise BadSTSPolicy()


### PR DESCRIPTION
**Purpose of proposed changes**

add default user-agent to override standard aiohttp user-agent + version info

**Essential steps taken**

- specified default user-agent in defaults.py 
- added empty headers dict in resolver.py and updated it with user-agent from defaults.py
- passed constructed headers dict onto get request

MTA-STS lookup now appear like this in webservers acces.log

`1.2.3.4 - - [xxx] "GET /.well-known/mta-sts.txt HTTP/1.1" 200 3727 "-" "postfix-mta-sts-resolver"
`

before:

`1.2.3.4 - - [xxx] "GET /.well-known/mta-sts.txt HTTP/1.1" 200 3727 "-" "Python/3.7 aiohttp/3.5.4"`