### PR TITLE
Make sqlite and redis dependencies optional

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,10 +22,12 @@ setup(name='postfix_mta_sts_resolver',
           'aiodns>=1.1.1',
           'aiohttp>=3.4.4',
           'PyYAML>=3.12',
-          'aiosqlite>=0.10.0',
-          'aioredis>=1.2.0',
           'sdnotify>=0.3.2',
       ],
+      extras_require={
+          'sqlite': 'aiosqlite>=0.10.0',
+          'redis': 'aioredis>=1.2.0',
+      },
       entry_points={
           'console_scripts': [
               'mta-sts-daemon=postfix_mta_sts_resolver.daemon:main',


### PR DESCRIPTION
**Purpose of proposed changes**

Make it possible to run the daemon without the aiosqlite and aioredis packages
installed, as long as those backends are not used by the running config.

This makes it easier for distribution packaging, where the package can have
optional dependencies on the libraries instead of always forcing an install of
them.

**Essential steps taken**

Change setup.py to declare the sqlite and redis dependencies as optional
features.