### PR TITLE
Add support for postfix [] and port notation

### DIFF
--- a/postfix_mta_sts_resolver/responder.py
+++ b/postfix_mta_sts_resolver/responder.py
@@ -11,7 +11,7 @@ import pynetstring
 
 from .resolver import STSResolver, STSFetchResult
 from .constants import QUEUE_LIMIT, CHUNK
-from .utils import create_custom_socket, create_cache
+from .utils import create_custom_socket, create_cache, filter_domain, is_ipaddr
 from .base_cache import CacheEntry
 
 
@@ -160,16 +160,12 @@ class STSSocketmapResponder:
 
         # Parse request and canonicalize domain
         req_zone, _, req_domain = raw_req.decode('latin-1').partition(' ')
-
-        domain = req_domain
+        domain = filter_domain(req_domain)
 
         # Skip lookups for parent domain policies
-        # Skip lookups to non-recepient domains or non-domains at all
-        if domain.startswith('.') or domain.startswith('[') or ':' in domain:
+        # Skip lookups to non-domains
+        if domain.startswith('.') or is_ipaddr(domain):
             return pynetstring.encode('NOTFOUND ')
-
-        # Normalize domain name
-        domain = req_domain.lower().strip().rstrip('.')
 
         # Find appropriate zone config
         if req_zone in self._zones:

--- a/postfix_mta_sts_resolver/utils.py
+++ b/postfix_mta_sts_resolver/utils.py
@@ -147,6 +147,24 @@ def is_plaintext(contenttype):
     return contenttype.lower().partition(';')[0].strip() == 'text/plain'
 
 
+def is_ipaddr(addr):
+    try:
+        socket.getaddrinfo(addr, None, flags=socket.AI_NUMERICHOST)
+        return True
+    except socket.gaierror:
+        return False
+
+
+def filter_domain(domain):
+    lpart, found_separator, rpart = domain.partition(']')
+    res = lpart.lstrip('[')
+    if not found_separator:
+        lpart, found_separator, rpart = domain.rpartition(':')
+        res = lpart if found_separator else rpart
+
+    return res.lower().strip().rstrip('.')
+
+
 def filter_text(strings):
     for string in strings:
         if isinstance(string, str):
@@ -179,6 +197,7 @@ async def create_custom_socket(host, port, *,  # pylint: disable=too-many-locals
 
     sock.bind(sa)
     return sock
+
 
 def create_cache(cache_type, options):
     if cache_type == "internal":

--- a/tests/refdata.tsv
+++ b/tests/refdata.tsv
@@ -1,11 +1,17 @@
 test good.loc	OK secure match=mail.loc
+test [good.loc]	OK secure match=mail.loc
+test [good.loc]:123	OK secure match=mail.loc
+test good.loc:123	OK secure match=mail.loc
 test2 good.loc	OK secure match=mail.loc
 test good.loc.	OK secure match=mail.loc
 test .good.loc	NOTFOUND 
 test valid-none.loc	NOTFOUND 
 test testing.loc	NOTFOUND 
 test no-record.loc	NOTFOUND 
+test [no-record.loc]	NOTFOUND 
 test .no-record.loc	NOTFOUND 
+test [1.2.3.4]	NOTFOUND 
+test [a:bb:ccc::dddd]:123	NOTFOUND 
 test bad-record1.loc	NOTFOUND 
 test bad-record2.loc	NOTFOUND 
 test bad-policy1.loc	NOTFOUND 

--- a/tests/refdata_strict.tsv
+++ b/tests/refdata_strict.tsv
@@ -1,11 +1,17 @@
 test good.loc	OK secure match=mail.loc
+test [good.loc]	OK secure match=mail.loc
+test [good.loc]:123	OK secure match=mail.loc
+test good.loc:123	OK secure match=mail.loc
 test2 good.loc	OK secure match=mail.loc
 test good.loc.	OK secure match=mail.loc
 test .good.loc	NOTFOUND 
 test valid-none.loc	NOTFOUND 
 test testing.loc	OK secure match=mail.loc
 test no-record.loc	NOTFOUND 
+test [no-record.loc]	NOTFOUND 
 test .no-record.loc	NOTFOUND 
+test [1.2.3.4]	NOTFOUND 
+test [a:bb:ccc::dddd]:123	NOTFOUND 
 test bad-record1.loc	NOTFOUND 
 test bad-record2.loc	NOTFOUND 
 test bad-policy1.loc	NOTFOUND 


### PR DESCRIPTION
**Changes**
When using a relay, special notation ([host]:port) is allowed for specifying the next-hop. Details: http://www.postfix.org/postconf.5.html#relayhost

This change addresses that by extracting the domain-like content from such a request and verifying it's not an IP address.

Change resolves #49

**Testing**
Added test cases to cover the changes. Verified all tests passing for tox's py36 test environment in a local Travis container.
