### PR TITLE
netstring: read(): introduce read limit

### DIFF
--- a/postfix_mta_sts_resolver/netstring.py
+++ b/postfix_mta_sts_resolver/netstring.py
@@ -49,7 +49,7 @@ class SingleNetstringFetcher:
     def done(self):
         return self._done
 
-    def read(self):
+    def read(self, nbytes=65536):
         # pylint: disable=too-many-branches
         if not self._len_known:
             # reading length
@@ -70,7 +70,7 @@ class SingleNetstringFetcher:
                     raise TooLong("Netstring length is over limit.")
         # reading data
         if self._len:
-            buf = self._incoming.read(self._len)
+            buf = self._incoming.read(min(nbytes, self._len))
             if not buf:
                 raise WantRead()
             self._len -= len(buf)


### PR DESCRIPTION
**Purpose of proposed changes**

This PR is not essential for pmsr project itself, but adds completeness to netstring module in it. Actual PR introduces string_reader.read() limit which is useful to restrict size of yielded chunk and workarounds situation when requested read larger than MemoryBIO internal limit (2GB).

**Essential steps taken**

See diff, it shows.
