### PR TITLE
fix #60

### DIFF
--- a/postfix_mta_sts_resolver/resolver.py
+++ b/postfix_mta_sts_resolver/resolver.py
@@ -68,7 +68,7 @@ class STSResolver:
             elif error.args[0] == aiodns.error.ARES_ENODATA:  # pylint: disable=no-else-return,no-member
                 return STSFetchResult.NONE, None
             else:  # pragma: no cover
-                return STSFetchResult.NONE, None
+                return STSFetchResult.FETCH_ERROR, None
         except asyncio.TimeoutError:
             return STSFetchResult.FETCH_ERROR, None
 


### PR DESCRIPTION
**Purpose of proposed changes**

Fixes #60

**Essential steps taken**

Changed error status for unknown errors to FETCH_ERROR since explicit denial of record existence (`NONE` status) is handled by `ARES_NOTFOUND` and `ARES_NODATA` exception branches and any other cases should be considered as a temporary error.