### PR TITLE
add debug logs for resolver

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -200,7 +200,7 @@ ignore-docstrings=yes
 ignore-imports=no
 
 # Minimum lines number of a similarity.
-min-similarity-lines=4
+min-similarity-lines=10
 
 
 [MISCELLANEOUS]

--- a/postfix_mta_sts_resolver/__main__.py
+++ b/postfix_mta_sts_resolver/__main__.py
@@ -4,10 +4,17 @@ import argparse
 import asyncio
 
 from .resolver import STSResolver
+from . import utils
+
 
 def parse_args():
     parser = argparse.ArgumentParser(
         formatter_class=argparse.ArgumentDefaultsHelpFormatter)
+    parser.add_argument("-v", "--verbosity",
+                        help="logging verbosity",
+                        type=utils.check_loglevel,
+                        choices=utils.LogLevel,
+                        default=utils.LogLevel.info)
     parser.add_argument("domain",
                         help="domain to fetch MTA-STS policy from")
     parser.add_argument("known_version",
@@ -20,10 +27,11 @@ def parse_args():
 
 def main():  # pragma: no cover
     args = parse_args()
-
-    loop = asyncio.get_event_loop()
-    resolver = STSResolver(loop=loop)
-    result = loop.run_until_complete(resolver.resolve(args.domain, args.known_version))
+    with utils.AsyncLoggingHandler(None) as log_handler:
+        utils.setup_logger('RES', args.verbosity, log_handler)
+        loop = asyncio.get_event_loop()
+        resolver = STSResolver(loop=loop)
+        result = loop.run_until_complete(resolver.resolve(args.domain, args.known_version))
     print(result)
 
 

--- a/postfix_mta_sts_resolver/daemon.py
+++ b/postfix_mta_sts_resolver/daemon.py
@@ -12,21 +12,14 @@ from . import utils
 from . import defaults
 from .proactive_fetcher import STSProactiveFetcher
 from .responder import STSSocketmapResponder
-from .utils import create_cache
 
 
 def parse_args():
-    def check_loglevel(arg):
-        try:
-            return utils.LogLevel[arg]
-        except (IndexError, KeyError):
-            raise argparse.ArgumentTypeError("%s is not valid loglevel" % (repr(arg),))
-
     parser = argparse.ArgumentParser(
         formatter_class=argparse.ArgumentDefaultsHelpFormatter)
     parser.add_argument("-v", "--verbosity",
                         help="logging verbosity",
-                        type=check_loglevel,
+                        type=utils.check_loglevel,
                         choices=utils.LogLevel,
                         default=utils.LogLevel.info)
     parser.add_argument("-c", "--config",
@@ -67,8 +60,8 @@ async def amain(cfg, loop):  # pragma: no cover
     proactive_fetch_enabled = cfg['proactive_policy_fetching']['enabled']
 
     # Create policy cache
-    cache = create_cache(cfg["cache"]["type"],
-                         cfg["cache"]["options"])
+    cache = utils.create_cache(cfg["cache"]["type"],
+                               cfg["cache"]["options"])
     await cache.setup()
 
     # Construct request handler
@@ -109,6 +102,7 @@ def main():  # pragma: no cover
         logger = utils.setup_logger('MAIN', args.verbosity, log_handler)
         utils.setup_logger('STS', args.verbosity, log_handler)
         utils.setup_logger('PF', args.verbosity, log_handler)
+        utils.setup_logger('RES', args.verbosity, log_handler)
         logger.info("MTA-STS daemon starting...")
 
         # Read config and populate with defaults

--- a/postfix_mta_sts_resolver/utils.py
+++ b/postfix_mta_sts_resolver/utils.py
@@ -4,6 +4,7 @@ import logging.handlers
 import asyncio
 import socket
 import queue
+import argparse
 
 import yaml
 
@@ -226,3 +227,10 @@ def create_cache(cache_type, options):
     else:
         raise NotImplementedError("Unsupported cache type!")
     return cache
+
+
+def check_loglevel(arg):
+    try:
+        return LogLevel[arg]
+    except (IndexError, KeyError):
+        raise argparse.ArgumentTypeError("%s is not valid loglevel" % (repr(arg),))


### PR DESCRIPTION
**Purpose of proposed changes**

Fix #62 

**Essential steps taken**

1. Moved argparse's check_loglevel adapter routine to utils.
2. Added logger instantiation in resolver and some logging during resolve process.
3. Added logger setup in CLI util `mta-sts-query`.