### PR TITLE
Update autotests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,11 @@
 language: python
-dist: xenial
+dist: bionic
 
 matrix:
   include:
-    - python: 3.8
+    - python: 3.9
       env: TOXENV=lint
-    - python: 3.8
+    - python: 3.9
       env: TOXENV=cover
     - python: 3.5
       env: TOXENV=py35
@@ -28,6 +28,8 @@ matrix:
     - python: 3.9
       env: TOXENV=py39-uvloop
 install:
+  - "sudo apt-get update"
+  - "sudo apt-get install -y build-essential libssl-dev libffi-dev python3-dev cargo"
   - "sudo -H env PYTHON=\"$(command -v python)\" tests/install.debian.sh"
 script:
   - tox

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,8 @@ matrix:
       env: TOXENV=py37
     - python: 3.8
       env: TOXENV=py38
+    - python: 3.9
+      env: TOXENV=py39
     - python: 3.5
       env: TOXENV=py35-uvloop
     - python: 3.6
@@ -23,6 +25,8 @@ matrix:
       env: TOXENV=py37-uvloop
     - python: 3.8
       env: TOXENV=py38-uvloop
+    - python: 3.9
+      env: TOXENV=py39-uvloop
 install:
   - "sudo -H env PYTHON=\"$(command -v python)\" tests/install.debian.sh"
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,10 +17,6 @@ matrix:
       env: TOXENV=py38
     - python: 3.9
       env: TOXENV=py39
-    - python: 3.5
-      env: TOXENV=py35-uvloop
-    - python: 3.6
-      env: TOXENV=py36-uvloop
     - python: 3.7
       env: TOXENV=py37-uvloop
     - python: 3.8

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,8 +28,6 @@ matrix:
     - python: 3.9
       env: TOXENV=py39-uvloop
 install:
-  - "sudo apt-get update"
-  - "sudo apt-get install -y build-essential libssl-dev libffi-dev python3-dev cargo"
   - "sudo -H env PYTHON=\"$(command -v python)\" tests/install.debian.sh"
 script:
   - tox

--- a/postfix_mta_sts_resolver/netstring.py
+++ b/postfix_mta_sts_resolver/netstring.py
@@ -145,4 +145,5 @@ def decode(data):
             yield b''.join(res)
     except WantRead:
         if reader.pending():
+            # pylint: disable=raise-missing-from
             raise IncompleteNetstring("Input ends on unfinished string.")

--- a/postfix_mta_sts_resolver/responder.py
+++ b/postfix_mta_sts_resolver/responder.py
@@ -260,6 +260,7 @@ class STSSocketmapResponder:
                     except netstring.WantRead:
                         part = await reader.read(CHUNK)
                         if not part:
+                            # pylint: disable=raise-missing-from
                             raise EndOfStream()
                         self._logger.debug("Read: %s", repr(part))
                         stream_reader.feed(part)

--- a/postfix_mta_sts_resolver/utils.py
+++ b/postfix_mta_sts_resolver/utils.py
@@ -11,6 +11,7 @@ import yaml
 from . import defaults
 
 
+# pylint: disable=invalid-name
 class LogLevel(enum.IntEnum):
     debug = logging.DEBUG
     info = logging.INFO
@@ -29,6 +30,7 @@ class OverflowingQueue(queue.Queue):
             return queue.Queue.put(self, item, block, timeout)
         except queue.Full:
             pass
+        return None
 
     def put_nowait(self, item):
         return self.put(item, False)
@@ -234,4 +236,5 @@ def check_loglevel(arg):
     try:
         return LogLevel[arg]
     except (IndexError, KeyError):
+        # pylint: disable=raise-missing-from
         raise argparse.ArgumentTypeError("%s is not valid loglevel" % (repr(arg),))

--- a/tests/dnsmasq.conf.appendix
+++ b/tests/dnsmasq.conf.appendix
@@ -2,6 +2,8 @@
 #bind-interfaces
 resolv-file=/etc/resolv-dnsmasq.conf
 
+address=/loc/127.0.0.1
+
 address=/mta-sts.bad-record1.loc/127.0.0.1
 txt-record=_mta-sts.bad-record1.loc,"id=20180907T090909; v=STSv1;"
 

--- a/tests/install.debian.sh
+++ b/tests/install.debian.sh
@@ -7,7 +7,8 @@ PYTHON="${PYTHON:-python3}"
 # run under travis, but not under autopkgtest
 if [ -z "${AUTOPKGTEST_TMP+x}" ] ; then
     apt-get update
-    apt-get install redis-server dnsmasq lsof nginx-extras tinyproxy -y
+    apt-get install -y redis-server dnsmasq lsof nginx-extras tinyproxy \
+		build-essential libssl-dev libffi-dev python3-dev cargo
     systemctl start redis-server || { journalctl -xe ; false ; }
     "$PYTHON" -m pip install cryptography
     "$PYTHON" -m pip install tox
@@ -52,7 +53,7 @@ systemctl restart nginx || { journalctl -xe ; false ; }
 
 # run under travis, but not under autopkgtest
 if [ -z "${AUTOPKGTEST_TMP+x}" ] ; then
-    install -m 644 -o root -g root tests/tinyproxy.conf /etc/tinyproxy.conf
+    install -m 644 -o root -g root tests/tinyproxy.conf /etc/tinyproxy/tinyproxy.conf
     systemctl restart tinyproxy || { journalctl -xe ; false ; }
     tests/expedite_proxy_startup.sh || { journalctl -xe ; false ; }
 else

--- a/tests/tinyproxy.conf
+++ b/tests/tinyproxy.conf
@@ -122,7 +122,7 @@ LogLevel Info
 # PidFile: Write the PID of the main tinyproxy thread to this file so it
 # can be used for signalling purposes.
 #
-PidFile "/run/tinyproxy/tinyproxy.pid"
+#PidFile "/run/tinyproxy/tinyproxy.pid"
 
 #
 # XTinyproxy: Tell Tinyproxy to include the X-Tinyproxy header, which

--- a/tests/tinyproxy.conf
+++ b/tests/tinyproxy.conf
@@ -12,8 +12,8 @@
 # as the root user. Either the user or group name or the UID or GID
 # number may be used.
 #
-User nobody
-Group nogroup
+User tinyproxy
+Group tinyproxy
 
 #
 # Port: Specify the port which tinyproxy will listen on.  Please note
@@ -92,14 +92,14 @@ StatFile "/usr/share/tinyproxy/stats.html"
 # and enable the Syslog directive.  These directives are mutually
 # exclusive.
 #
-Logfile "/var/log/tinyproxy/tinyproxy.log"
+#Logfile "/var/log/tinyproxy/tinyproxy.log"
 
 #
 # Syslog: Tell tinyproxy to use syslog instead of a logfile.  This
 # option must not be enabled if the Logfile directive is being used.
 # These two directives are mutually exclusive.
 #
-#Syslog On
+Syslog On
 
 #
 # LogLevel: 
@@ -122,7 +122,7 @@ LogLevel Info
 # PidFile: Write the PID of the main tinyproxy thread to this file so it
 # can be used for signalling purposes.
 #
-#PidFile "/run/tinyproxy/tinyproxy.pid"
+PidFile "/run/tinyproxy/tinyproxy.pid"
 
 #
 # XTinyproxy: Tell Tinyproxy to include the X-Tinyproxy header, which

--- a/tox.ini
+++ b/tox.ini
@@ -10,14 +10,14 @@ commands =
     pytest .
 
 [testenv:lint]
-basepython = python3.8
+basepython = python3.9
 commands =
     pip install -e '.[dev,sqlite,redis]'
     pylint --reports=n --rcfile=.pylintrc postfix_mta_sts_resolver
 
 [testenv:cover]
 passenv = TOXENV
-basepython = python3.8
+basepython = python3.9
 commands =
     pip install -e ".[dev,sqlite,redis]"
     pytest --cov . --cov-append --cov-report= .

--- a/tox.ini
+++ b/tox.ini
@@ -1,12 +1,12 @@
 [tox]
-envlist = py{35,36,37,38,39}{,-uvloop}, lint, cover
+envlist = py{35,36,37,38,39}, py{37,38,39}-uvloop, lint, cover
 skipsdist = true
 
 [testenv]
 passenv = TOXENV
 commands =
     py{35,36,37,38,39}: pip install -e '.[dev,sqlite,redis]'
-    py{35,36,37,38,39}-uvloop: pip install -e '.[dev,sqlite,redis,uvloop]'
+    py{37,38,39}-uvloop: pip install -e '.[dev,sqlite,redis,uvloop]'
     pytest .
 
 [testenv:lint]

--- a/tox.ini
+++ b/tox.ini
@@ -1,12 +1,12 @@
 [tox]
-envlist = py{35,36,37,38}{,-uvloop}, lint, cover
+envlist = py{35,36,37,38,39}{,-uvloop}, lint, cover
 skipsdist = true
 
 [testenv]
 passenv = TOXENV
 commands =
-    py{35,36,37,38}: pip install -e '.[dev,sqlite,redis]'
-    py{35,36,37,38}-uvloop: pip install -e '.[dev,sqlite,redis,uvloop]'
+    py{35,36,37,38,39}: pip install -e '.[dev,sqlite,redis]'
+    py{35,36,37,38,39}-uvloop: pip install -e '.[dev,sqlite,redis,uvloop]'
     pytest .
 
 [testenv:lint]


### PR DESCRIPTION
**Purpose of proposed changes**

Keep CI up to date

**Essential steps taken**

* Add Python 3.9 to test env matrix
* Add build dependencies for `cryptography` package (required only for autotests)
* Switch coverage and linting tests to latest python version
* Fix linting to adhere latest pylint requirements
* Switch test env distro to Ubuntu 18.04 and make according changes in test env configs
* Drop tests with uvloop on Python<3.7 since uvloop upstream doesn't seem to support older Python versions anymore