### PR TITLE
Limit aioredis version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ setup(name='postfix_mta_sts_resolver',
       ],
       extras_require={
           'sqlite': 'aiosqlite>=0.10.0',
-          'redis': 'aioredis>=1.2.0',
+          'redis': 'aioredis>=1.2.0,<2.0.0',
           'dev': [
               'pytest>=3.0.0',
               'pytest-cov',

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -13,7 +13,7 @@ parts:
     python-version: python3
     python-packages:
       - "aiosqlite>=0.10.0"
-      - "aioredis>=1.2.0"
+      - "aioredis>=1.2.0,<2.0.0"
     build-packages:
       - gcc
       - make


### PR DESCRIPTION
**Purpose of proposed changes**

The latest Docker image is broken since it pulled aioredis 2.0, which no
longer has aioredis.create_redis_pool().
