### PR TITLE
Tests: Avoid 3rd party stderr breaking autopkgtest.

### DIFF
--- a/tests/install.debian.sh
+++ b/tests/install.debian.sh
@@ -44,7 +44,7 @@ mkdir -p /tmp/certs /tmp/bad-certs
 
 mkdir -p /usr/local/share/ca-certificates/test
 install -m 644 -o root -g root /tmp/certs/ca.pem /usr/local/share/ca-certificates/test/test-ca.crt
-update-ca-certificates
+update-ca-certificates 2>&1
 
 
 install -m 644 tests/nginx.conf /etc/nginx/nginx.conf


### PR DESCRIPTION
In `install.debian.sh`:

Recent update-ca-certificates may output on stderr, even when the command succeeds. This causes autopkgtest to consider a test run failed.

The long-term fix will hopefully happen in openssl, in the mean time we can work around the issue. Ignoring stderr should be safe: if update-ca-certificates in the testsuite would not work correctly, the certificates will not be installed and the test will fail safely. 

In case you're interested in the full story, see https://bugs.debian.org/996048 ;-)