### PR TITLE
Migrate from aioredis to redis-py

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ You can say thanks to the author by donations to these wallets:
 * aiodns
 * aiohttp
 * aiosqlite
-* aioredis
+* redis-py
 * PyYAML
 * (optional) uvloop
 

--- a/postfix_mta_sts_resolver/redis_cache.py
+++ b/postfix_mta_sts_resolver/redis_cache.py
@@ -1,12 +1,9 @@
 import json
 import uuid
 
-import aioredis
+from redis import asyncio as aioredis
 from . import defaults
 from .base_cache import BaseCache, CacheEntry
-
-# Remove once fixed: https://github.com/aio-libs/aioredis-py/issues/1115
-aioredis.Redis.__del__ = lambda *args: None  # type: ignore
 
 def pack_entry(entry):
     ts, pol_id, pol_body = entry  # pylint: disable=invalid-name,unused-variable

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ setup(name='postfix_mta_sts_resolver',
       ],
       extras_require={
           'sqlite': 'aiosqlite>=0.10.0',
-          'redis': 'aioredis>=2.0.0',
+          'redis': 'redis>=4.2.0rc1',
           'dev': [
               'pytest>=3.0.0',
               'pytest-cov',

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -13,7 +13,7 @@ parts:
     python-version: python3
     python-packages:
       - "aiosqlite>=0.10.0"
-      - "aioredis>=2.0.0"
+      - "redis>=4.2.0rc1"
     build-packages:
       - gcc
       - make


### PR DESCRIPTION
See https://github.com/aio-libs/aioredis-py/issues/1301 for reference

**Purpose of proposed changes**

Aioredis is now redis-py

**Essential steps taken**

Ported all the existing references to aioredis to their new locations.
