### PR TITLE
fix tests

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+asyncio_mode = legacy


### PR DESCRIPTION
**Purpose of proposed changes**

Fix tests after release of pytest-asyncio 0.19.0

**Essential steps taken**

Added pytest config explicitly setting `asyncio_mode` to `legacy`.
