### PR TITLE
Fix tests

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,2 +1,2 @@
 [pytest]
-asyncio_mode = legacy
+asyncio_mode = auto


### PR DESCRIPTION
**Purpose of proposed changes**

Fix config for pytest-asyncio due to recent changes in pytest-asyncio==0.20.0

**Essential steps taken**

Changed `asyncio_mode` to `auto` in the pytest config. It seem to work as good as `legacy` mode, while `legacy` mode is not available for pytest-asyncio>=0.20.0