### PR TITLE
add command-line options "-g", "-u", "-p"

### DIFF
--- a/man/mta-sts-daemon.1.adoc
+++ b/man/mta-sts-daemon.1.adoc
@@ -29,12 +29,21 @@ successful authentication of that site when forwarding mail there.
 *-v, --verbosity* _VERBOSITY_::
   set log verbosity level: _debug_, _info_ (default), _warn_, _error_, or
   _fatal_.
-
 *-c, --config* _FILE_::
   config file location (default: _/etc/mta-sts-daemon.yml_)
 
+*-g, --group* _GROUP_::
+  change eGID to this group (default: _none_)
+
 *-l, --logfile* _FILE_::
   log file location (default: _none_)
+
+*-p, --pidfile* _PIDFILE_::
+  name of the file to write the current pid to (default: _none_)
+
+*-u, --user* _USER_::
+  change eUID to this user (default: _none_)
+
 
 *--disable-uvloop*::
   do not use uvloop even if it is available (default: enabled if available)


### PR DESCRIPTION
-g GROUP, --group GROUP          change eGID to this group (default: None)

-p PIDFILE, --pidfile PIDFILE    name of the file to write the current pid to (default: None)
-u USER, --user USER             change eUID to this user (default: None)

**Purpose of proposed changes**

With these changes, it is easier to run the daemon as a daemon (although it still doesn't daemonize :-).
That is, you can specify a pidfile for the daemon to write its PID to, and specify a username/groupname to have the daemon change to at startup.  This allows you to kick off mta-sts-daemon via normal startup scripts as root and then have the daemon run unprivileged without having to play sudo/su games.

**Essential steps taken**

At daemon startup time, try to write the pid (prior to changing eUID), then change group (prior to changing eUID), then finally change eUID. 