### PR TITLE
Use stable scan query

### DIFF
--- a/postfix_mta_sts_resolver/postgres_cache.py
+++ b/postfix_mta_sts_resolver/postgres_cache.py
@@ -90,7 +90,7 @@ class PostgresCache(BaseCache):
 
         async with self._pool.acquire(timeout=self._timeout) as conn, conn.transaction():
             res = await conn.fetch('SELECT id, ts, pol_id, pol_body, domain FROM '
-                                    'sts_policy_cache WHERE id >= $1 LIMIT $2',
+                                    'sts_policy_cache WHERE id >= $1 ORDER BY id ASC LIMIT $2',
                                     token, amount_hint)
         if res:
             result = []


### PR DESCRIPTION
PostgreSQL may return rows in arbitrary order without an order clause. If it returned the maximum id in the first batch, consecutive batches would be empty and terminate the scan.