### PR TITLE
fix link and add meta data to identify the message

### DIFF
--- a/README.md
+++ b/README.md
@@ -275,4 +275,4 @@ Second option - specify new path in shebang of scripts installed in virtualenv. 
 
 ## Credits
 
-Inspired by [this forum thread](http://postfix.1071664.n5.nabble.com/MTA-STS-when-td95086.html).
+Inspired by [a postfix-user mailing list thread](https://marc.info/?l=postfix-users&m=151889071727364&w=2) (subject: 'MTA-STS when?', first message: 2018-02-17).


### PR DESCRIPTION
NB: marc.info is also linked from the postfix mailing list page:

https://www.postfix.org/lists.html

**Purpose of proposed changes**

fix the link to the thread that inspired this proejct

**Essential steps taken**

I went to the internet archive to resurrect the old link and determine the message subject/author/date in order to find it in the official archive and thus get a more stable link.