### PR TITLE
Minimal support for TLSRPT in Postfix 3.10 and later

### DIFF
--- a/config_examples/mta-sts-daemon.yml.internal
+++ b/config_examples/mta-sts-daemon.yml.internal
@@ -2,6 +2,7 @@ host: 127.0.0.1
 port: 8461
 reuse_port: true
 shutdown_timeout: 20
+# tlsrpt: true
 cache:
   type: internal
   options:

--- a/config_examples/mta-sts-daemon.yml.postgres
+++ b/config_examples/mta-sts-daemon.yml.postgres
@@ -2,6 +2,7 @@ host: 127.0.0.1
 port: 8461
 reuse_port: true
 shutdown_timeout: 20
+# tlsrpt: true
 cache:
   type: postgres
   options:

--- a/config_examples/mta-sts-daemon.yml.redis
+++ b/config_examples/mta-sts-daemon.yml.redis
@@ -2,6 +2,7 @@ host: 127.0.0.1
 port: 8461
 reuse_port: true
 shutdown_timeout: 20
+# tlsrpt: true
 cache:
   type: redis
   options:

--- a/config_examples/mta-sts-daemon.yml.redis_sentinel
+++ b/config_examples/mta-sts-daemon.yml.redis_sentinel
@@ -2,6 +2,7 @@ host: 127.0.0.1
 port: 8461
 reuse_port: true
 shutdown_timeout: 20
+# tlsrpt: true
 cache:
   type: redis_sentinel
   options:

--- a/config_examples/mta-sts-daemon.yml.sqlite
+++ b/config_examples/mta-sts-daemon.yml.sqlite
@@ -2,6 +2,7 @@ host: 127.0.0.1
 port: 8461
 reuse_port: true
 shutdown_timeout: 20
+# tlsrpt: true
 cache:
   type: sqlite
   options:

--- a/config_examples/mta-sts-daemon.yml.sqlite_unixsock
+++ b/config_examples/mta-sts-daemon.yml.sqlite_unixsock
@@ -1,6 +1,7 @@
 path: "/var/run/mta-sts.sock"
 mode: 0666
 shutdown_timeout: 20
+# tlsrpt: true
 cache:
   type: sqlite
   options:

--- a/man/mta-sts-daemon.yml.5.adoc
+++ b/man/mta-sts-daemon.yml.5.adoc
@@ -30,6 +30,8 @@ The file is in YAML syntax with the following elements:
 
 *shutdown_timeout*: (_float_) time limit granted to existing client sessions for finishing when server stops. Default: 20
 
+*tlsrpt*: (_bool_) include response attributes for TLSRPT support (Postfix 3.10 and later). Default: false
+
 *cache*::
 
 * *type*: (_str_: _internal_|_sqlite_|_redis_|_redis_sentinel_|postgres) cache backend type. Default: internal

--- a/postfix_mta_sts_resolver/defaults.py
+++ b/postfix_mta_sts_resolver/defaults.py
@@ -4,6 +4,7 @@ HOST = "127.0.0.1"
 PORT = 8461
 REUSE_PORT = True
 TIMEOUT = 4
+TLSRPT = False
 SHUTDOWN_TIMEOUT = 20
 STRICT_TESTING = False
 CONFIG_LOCATION = "/etc/mta-sts-daemon.yml"

--- a/postfix_mta_sts_resolver/responder.py
+++ b/postfix_mta_sts_resolver/responder.py
@@ -33,6 +33,7 @@ class STSSocketmapResponder:
             self._port = cfg['port']
         self._reuse_port = cfg['reuse_port']
         self._shutdown_timeout = cfg['shutdown_timeout']
+        self._tlsrpt = cfg['tlsrpt']
         self._grace = cfg['cache_grace']
 
         # Construct configurations and resolvers for every socketmap name
@@ -225,6 +226,8 @@ class STSSocketmapResponder:
                 resp = "OK secure match=" + ":".join(mxlist)
                 if zone_cfg.require_sni:
                     resp += " servername=hostname"
+                if self._tlsrpt:
+                    resp += " policy_type=sts policy_domain=" + domain
                 return netstring.encode(resp.encode('utf-8'))
         else:
             return netstring.encode(b'NOTFOUND ')

--- a/postfix_mta_sts_resolver/utils.py
+++ b/postfix_mta_sts_resolver/utils.py
@@ -87,6 +87,7 @@ def populate_cfg_defaults(cfg):
     cfg['reuse_port'] = cfg.get('reuse_port', defaults.REUSE_PORT)
     cfg['shutdown_timeout'] = cfg.get('shutdown_timeout',
                                       defaults.SHUTDOWN_TIMEOUT)
+    cfg['tlsrpt'] = cfg.get('tlsrpt', defaults.TLSRPT)
     cfg['cache_grace'] = cfg.get('cache_grace', defaults.CACHE_GRACE)
 
     if 'proactive_policy_fetching' not in cfg:


### PR DESCRIPTION
**Purpose of proposed changes**

TLSRPT is a protocol to report TLS success and failure events to a domain owner. It is defined in RFC 8640. It is supported in Postfix 3.10 and later. The report includes a policy type ('dane' or 'sts'), a policy domain, and policy details. 

This pull request introduces the minimum attributes for TLSRPT in the daemon response: the policy type '(sts') and the policy domain name. The attributes are disabled by default, and can be turned on by setting 'tlsrpt: True' in the configuration YAML.

**Essential steps taken**

- A new configuration setting 'tlsrpt', default False, with updated documentation and example YAML files.

- Code to conditionally emit the new policy_type and policy_domain attributes.

This is easily extended to include more policy attributes, but that should probably be done by someone who is more familiar with Python.