### PR TITLE
TLSRPT follow-up updates

### DIFF
--- a/config_examples/mta-sts-daemon.yml.internal
+++ b/config_examples/mta-sts-daemon.yml.internal
@@ -2,7 +2,6 @@ host: 127.0.0.1
 port: 8461
 reuse_port: true
 shutdown_timeout: 20
-# tlsrpt: true
 cache:
   type: internal
   options:
@@ -10,6 +9,7 @@ cache:
 default_zone:
   strict_testing: false
   timeout: 4
+  #tlsrpt: true
 zones:
   myzone:
     strict_testing: false

--- a/config_examples/mta-sts-daemon.yml.postgres
+++ b/config_examples/mta-sts-daemon.yml.postgres
@@ -2,7 +2,6 @@ host: 127.0.0.1
 port: 8461
 reuse_port: true
 shutdown_timeout: 20
-# tlsrpt: true
 cache:
   type: postgres
   options:
@@ -10,6 +9,7 @@ cache:
 default_zone:
   strict_testing: false
   timeout: 4
+  #tlsrpt: true
 zones:
   myzone:
     strict_testing: false

--- a/config_examples/mta-sts-daemon.yml.redis
+++ b/config_examples/mta-sts-daemon.yml.redis
@@ -2,7 +2,6 @@ host: 127.0.0.1
 port: 8461
 reuse_port: true
 shutdown_timeout: 20
-# tlsrpt: true
 cache:
   type: redis
   options:
@@ -13,6 +12,7 @@ cache:
 default_zone:
   strict_testing: false
   timeout: 4
+  #tlsrpt: true
 zones:
   myzone:
     strict_testing: false

--- a/config_examples/mta-sts-daemon.yml.redis_sentinel
+++ b/config_examples/mta-sts-daemon.yml.redis_sentinel
@@ -2,7 +2,6 @@ host: 127.0.0.1
 port: 8461
 reuse_port: true
 shutdown_timeout: 20
-# tlsrpt: true
 cache:
   type: redis_sentinel
   options:
@@ -18,6 +17,7 @@ cache:
 default_zone:
   strict_testing: false
   timeout: 4
+  #tlsrpt: true
 zones:
   myzone:
     strict_testing: false

--- a/config_examples/mta-sts-daemon.yml.sqlite
+++ b/config_examples/mta-sts-daemon.yml.sqlite
@@ -2,7 +2,6 @@ host: 127.0.0.1
 port: 8461
 reuse_port: true
 shutdown_timeout: 20
-# tlsrpt: true
 cache:
   type: sqlite
   options:
@@ -10,6 +9,7 @@ cache:
 default_zone:
   strict_testing: false
   timeout: 4
+  #tlsrpt: true
 zones:
   myzone:
     strict_testing: false

--- a/config_examples/mta-sts-daemon.yml.sqlite_unixsock
+++ b/config_examples/mta-sts-daemon.yml.sqlite_unixsock
@@ -1,7 +1,6 @@
 path: "/var/run/mta-sts.sock"
 mode: 0666
 shutdown_timeout: 20
-# tlsrpt: true
 cache:
   type: sqlite
   options:
@@ -9,6 +8,7 @@ cache:
 default_zone:
   strict_testing: false
   timeout: 4
+  #tlsrpt: true
 zones:
   myzone:
     strict_testing: false

--- a/man/mta-sts-daemon.yml.5.adoc
+++ b/man/mta-sts-daemon.yml.5.adoc
@@ -30,8 +30,6 @@ The file is in YAML syntax with the following elements:
 
 *shutdown_timeout*: (_float_) time limit granted to existing client sessions for finishing when server stops. Default: 20
 
-*tlsrpt*: (_bool_) include response attributes for TLSRPT support (Postfix 3.10 and later). Default: false
-
 *cache*::
 
 * *type*: (_str_: _internal_|_sqlite_|_redis_|_redis_sentinel_|postgres) cache backend type. Default: internal
@@ -64,6 +62,7 @@ It is unaffected by `cache_grace` and vice versa. Default: 86400
 * *strict_testing*: (_bool_) enforce policy for testing domains. Default: false
 * *timeout*: (_int_) network operations timeout for resolver in that zone. Default: 4
 * *require_sni*: (_bool_) add option `servername=hostname` to policy responses to make Postfix send SNI in TLS handshake as required by RFC 8461. Requires Postfix version 3.4+. Default: true
+* *tlsrpt*: (_bool_) include response attributes for TLSRPT support (Postfix 3.10 and later). Default: false
 
 *zones*::
 

--- a/postfix_mta_sts_resolver/responder.py
+++ b/postfix_mta_sts_resolver/responder.py
@@ -229,6 +229,7 @@ class STSSocketmapResponder:
                     resp += " servername=hostname"
                 if zone_cfg.tlsrpt:
                     resp += " policy_type=sts policy_domain=" + domain
+                    resp += " " + " ".join("mx_host_pattern=" + mx for mx in cached.pol_body['mx'])
                 return netstring.encode(resp.encode('utf-8'))
         else:
             return netstring.encode(b'NOTFOUND ')

--- a/postfix_mta_sts_resolver/responder.py
+++ b/postfix_mta_sts_resolver/responder.py
@@ -230,6 +230,10 @@ class STSSocketmapResponder:
                 if zone_cfg.tlsrpt:
                     resp += " policy_type=sts policy_domain=" + domain
                     resp += " " + " ".join("mx_host_pattern=" + mx for mx in cached.pol_body['mx'])
+                    resp += " " + " ".join(
+                            "{ policy_string = %s: %s }" % (k, v) if k != "mx" else
+                            " ".join("{ policy_string = mx: %s }" % (mx,) for mx in v)
+                            for k, v in cached.pol_body.items())
                 return netstring.encode(resp.encode('utf-8'))
         else:
             return netstring.encode(b'NOTFOUND ')

--- a/postfix_mta_sts_resolver/utils.py
+++ b/postfix_mta_sts_resolver/utils.py
@@ -87,7 +87,6 @@ def populate_cfg_defaults(cfg):
     cfg['reuse_port'] = cfg.get('reuse_port', defaults.REUSE_PORT)
     cfg['shutdown_timeout'] = cfg.get('shutdown_timeout',
                                       defaults.SHUTDOWN_TIMEOUT)
-    cfg['tlsrpt'] = cfg.get('tlsrpt', defaults.TLSRPT)
     cfg['cache_grace'] = cfg.get('cache_grace', defaults.CACHE_GRACE)
 
     if 'proactive_policy_fetching' not in cfg:
@@ -117,6 +116,7 @@ def populate_cfg_defaults(cfg):
         zone['timeout'] = zone.get('timeout', defaults.TIMEOUT)
         zone['strict_testing'] = zone.get('strict_testing', defaults.STRICT_TESTING)
         zone['require_sni'] = zone.get('require_sni', defaults.REQUIRE_SNI)
+        zone['tlsrpt'] = zone.get('tlsrpt', defaults.TLSRPT)
         return zone
 
     if 'default_zone' not in cfg:


### PR DESCRIPTION
**Purpose of proposed changes**

* Makes TLSRPT reporting configurable on per-zone basis.
* Send mx_host_pattern attributes along with policy response.

Related #107 

**Essential steps taken**

Moved config property to zone section and updated corresponding references. Also updated structure of ZoneEntry.

Exported MX list from STS policy retaining original `*` for wildcard names (as the opposite to match list which uses `.domain.tld` format for wildcards).

CC @wietse-postfix for review.