### PR TITLE
Change event loop to use new event loop instance

### DIFF
--- a/postfix_mta_sts_resolver/__main__.py
+++ b/postfix_mta_sts_resolver/__main__.py
@@ -29,7 +29,8 @@ def main():  # pragma: no cover
     args = parse_args()
     with utils.AsyncLoggingHandler(None) as log_handler:
         utils.setup_logger('RES', args.verbosity, log_handler)
-        loop = asyncio.get_event_loop()
+        loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(loop)
         resolver = STSResolver(loop=loop)
         result = loop.run_until_complete(resolver.resolve(args.domain, args.known_version))
     print(result)

--- a/postfix_mta_sts_resolver/daemon.py
+++ b/postfix_mta_sts_resolver/daemon.py
@@ -142,6 +142,7 @@ def main():  # pragma: no cover
                 logger.info("uvloop is not available. "
                             "Falling back to built-in event loop.")
         evloop = asyncio.new_event_loop()
+        asyncio.set_event_loop(evloop)
         logger.info("Eventloop started.")
 
 

--- a/postfix_mta_sts_resolver/daemon.py
+++ b/postfix_mta_sts_resolver/daemon.py
@@ -141,7 +141,7 @@ def main():  # pragma: no cover
             else:
                 logger.info("uvloop is not available. "
                             "Falling back to built-in event loop.")
-        evloop = asyncio.get_event_loop()
+        evloop = asyncio.new_event_loop()
         logger.info("Eventloop started.")
 
 


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=2403087

**Purpose of proposed changes**

Python 3.14 has made calling `get_event_loop` throw if there's no current event loop. `new_event_loop` creates a new loop and returns it, which seems like the right thing to do here.

**Essential steps taken**

See the `Changed in version 3.14` section of <https://docs.python.org/3.14/library/asyncio-eventloop.html#asyncio.get_event_loop>
