### PR TITLE
fix bdist_wheel deprecation

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools >= 42.0.0"]
+build-backend = "setuptools.build_meta"


### PR DESCRIPTION
**Purpose of proposed changes**

Fix pip warning about bdist_wheel deprecation.

**Essential steps taken**

Followed steps from https://github.com/pypa/pip/issues/6334